### PR TITLE
Reflect renaming of organization on GitHub

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,4 @@
-Library Carpentry is authored and maintained by the [community](https://github.com/data-lessons/library-python/network/members).
+Library Carpentry is authored and maintained by the [community](https://github.com/LibraryCarpentry/library-python/network/members).
 
 Credit for the Library Carpentry logos goes to [Tammy Nguyen](https://twitter.com/tammysongnguyen).
 

--- a/CITATION
+++ b/CITATION
@@ -2,4 +2,4 @@ Please cite as:
 
 Library Carpentry:
 "Data Intro for Librarians."
-June 2016, http://data-lessons.github.io/library-data-intro/.
+June 2016, http://LibraryCarpentry.github.io/library-data-intro/.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 There are three main ways to contribute to Library Carpentry:
 
 - Join our [Gitter discussion forum](https://gitter.im/weaverbel/LibraryCarpentry). Here you can suggest new content, volunteer to become a lesson maintainer, or help shape future developments.
-- Suggest an improvement or correct an error by [raising an Issue](https://github.com/data-lessons/library-data-intro/issues).
+- Suggest an improvement or correct an error by [raising an Issue](https://github.com/LibraryCarpentry/library-data-intro/issues).
 - Run a workshop at your own institution! If you do, alert us on [Gitter](https://gitter.im/weaverbel/LibraryCarpentry): we’re happy to help promote the workshop and offer guidance on running it. Remember, there is no better way to deepen your own knowledge of software skills than to teach others.
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Library Carpentry
 
-The Library Carpentry module '[Python for Librarians](http://data-lessons.github.io/library-python/)' is maintained by 
+The Library Carpentry module '[Python for Librarians](http://LibraryCarpentry.github.io/library-python/)' is maintained by 
 by [Carlos Martinez](https://github.com/c-martinez) and [Richard Vankoningsveld](https://github.com/richyvk).
 
 
@@ -16,7 +16,7 @@ There are many ways of contributing to Library Carpentry:
 
 - Join our [Gitter discussion forum](https://gitter.im/LibraryCarpentry/).
 - Follow updates on [Twitter](https://twitter.com/LibCarpentry).
-- Make a suggestion or correct an error by [raising an Issue](https://github.com/data-lessons/library-python/issues).
+- Make a suggestion or correct an error by [raising an Issue](https://github.com/LibraryCarpentry/library-python/issues).
 
 ## Code of Conduct
 
@@ -24,10 +24,10 @@ All participants should agree to abide by the [Software Carpentry Code of Conduc
 
 ## Authors
 
-Library Carpentry is authored and maintained by the [community](https://github.com/data-lessons/library-openrefine/network/members).
+Library Carpentry is authored and maintained by the [community](https://github.com/LibraryCarpentry/library-openrefine/network/members).
 
 ## Citation
 
 Please cite as:
 
-Library Carpentry. Python for Librarians. June 2016. http://data-lessons.github.io/library-python/.
+Library Carpentry. Python for Librarians. June 2016. http://LibraryCarpentry.github.io/library-python/.

--- a/_extras/discuss.md
+++ b/_extras/discuss.md
@@ -7,4 +7,4 @@ There are many ways to discuss Library Carpentry lessons:
 
 - Join our [Gitter discussion forum]({{ site.contact }}).
 - Follow updates on [Twitter](https://twitter.com/LibCarpentry).
-- Make a suggestion or correct an error by [raising an Issue](https://github.com/data-lessons/library-python/issues).
+- Make a suggestion or correct an error by [raising an Issue](https://github.com/LibraryCarpentry/library-python/issues).


### PR DESCRIPTION
See diff ;-)

However, is this entire repo a duplicate of [LibraryCarpentry/lc-python-intro](https://github.com/LibraryCarpentry/lc-python-intro)? cc @weaverbel

If yes, please [archive](https://help.github.com/articles/archiving-repositories/) one of them quickly.